### PR TITLE
Clone of thijzert's pullrequest #96

### DIFF
--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -419,6 +419,8 @@ class XMLSecEnc
         $xpath = new DOMXPath($doc);
         $xpath->registerNamespace('xmlsecenc', self::XMLENCNS);
         $xpath->registerNamespace('xmlsecdsig', XMLSecurityDSig::XMLDSIGNS);
+        $xpath->registerNamespace('wsse', XMLSecurityDSig::WSSENS);
+        $xpath->registerNamespace('wsu', XMLSecurityDSig::WSUNS);
         $query = "./xmlsecdsig:KeyInfo";
         $nodeset = $xpath->query($query, $node);
         $encmeth = $nodeset->item(0);
@@ -457,6 +459,35 @@ class XMLSecEnc
                         }
                     }
                     break;
+				case 'SecurityTokenReference':
+					$query = "./wsse:Reference";
+					$keyRefElement = $xpath->query($query, $child)->item(0);
+					if (!$keyRefElement) {
+						throw new Exception("Unable to locate reference within SecurityTokenReference");
+					}
+					$uri = $keyRefElement->getAttribute('URI');
+					if (substr($uri,0,1) !== '#') {
+						/* URI not a reference - unsupported. */
+						break;
+					}
+					$id = substr($uri, 1);
+
+					$query = "//wsse:BinarySecurityToken[@Id='$id']";
+					$keyElement = $xpath->query($query)->item(0);
+					if (!$keyElement) {
+						$query = "//wsse:BinarySecurityToken[@wsu:Id='$id']";
+						$keyElement = $xpath->query($query)->item(0);
+						if (!$keyElement) {
+							throw new Exception("Unable to locate BinarySecurityToken with @Id='$id'.");
+						}
+					}
+
+					$x509cert = $keyElement->textContent;
+					$x509cert = str_replace(array("\r", "\n", " "), "", $x509cert);
+					$x509cert = "-----BEGIN CERTIFICATE-----\n".chunk_split($x509cert, 64, "\n")."-----END CERTIFICATE-----\n";
+					$objBaseKey->loadKey($x509cert, false, true);
+				    break;
+
                 case 'RetrievalMethod':
                     $type = $child->getAttribute('Type');
                     if ($type !== 'http://www.w3.org/2001/04/xmlenc#EncryptedKey') {

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -50,6 +50,8 @@ use Exception;
 class XMLSecurityDSig
 {
     const XMLDSIGNS = 'http://www.w3.org/2000/09/xmldsig#';
+    const WSSENS = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+    const WSUNS = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd';
     const SHA1 = 'http://www.w3.org/2000/09/xmldsig#sha1';
     const SHA256 = 'http://www.w3.org/2001/04/xmlenc#sha256';
     const SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#sha384';
@@ -75,6 +77,9 @@ class XMLSecurityDSig
 
     /** @var DOMElement|null */
     public $sigNode = null;
+
+    /** @var array */
+    public $securityTokenNodes = array();
 
     /** @var array */
     public $idKeys = array();
@@ -592,6 +597,7 @@ class XMLSecurityDSig
                 throw new Exception("Reference validation failed");
             }
         }
+
         return true;
     }
 
@@ -864,10 +870,17 @@ class XMLSecurityDSig
         $signatureElement = $document->importNode($this->sigNode, true);
 
         if ($beforeNode == null) {
-            return $node->insertBefore($signatureElement);
+            $rv = $node->insertBefore($signatureElement);
         } else {
-            return $node->insertBefore($signatureElement, $beforeNode);
+            $rv = $node->insertBefore($signatureElement, $beforeNode);
         }
+
+        foreach ($this->securityTokenNodes as $st) {
+            $stt = $document->importNode($st, true);
+            $node->insertBefore($stt, $rv);
+        }
+
+        return $rv;
     }
 
     /**
@@ -1059,6 +1072,96 @@ class XMLSecurityDSig
     {
         if ($xpath = $this->getXPathObj()) {
             self::staticAdd509Cert($this->sigNode, $cert, $isPEMFormat, $isURL, $xpath, $options);
+        }
+    }
+
+    /**
+     * @param string $cert
+     * @param bool $isPEMFormat
+     * @param bool $isURL
+     * @param null|DOMXPath $xpath
+     * @param null|array $options
+     * @throws Exception
+     */
+    public function add509CertByReference($cert, $isPEMFormat=true, $isURL=false, $xpath=null, $options=null)
+    {
+        if ($isURL) {
+            $cert = file_get_contents($cert);
+        }
+        $baseDoc = $this->sigNode->ownerDocument;
+
+        if (empty($xpath)) {
+            $xpath = new DOMXPath($this->sigNode->ownerDocument);
+            $xpath->registerNamespace('secdsig', self::XMLDSIGNS);
+        }
+
+        $key_id_ns = null;
+        $key_id_pfx = "";
+        $key_id_name = "Id";
+        if (! empty($options["key_id_prefix"]))    { $key_id_pfx  = $options["key_id_prefix"]; }
+        if (! empty($options["key_id_prefix_ns"])) { $key_id_ns   = $options["key_id_prefix_ns"]; }
+        if (! empty($options["key_id_name"]))      { $key_id_name = $options["key_id_name"]; }
+
+        $query = "./secdsig:KeyInfo";
+        $nodeset = $xpath->query($query, $this->sigNode);
+        $keyInfo = $nodeset->item(0);
+        $dsig_pfx = '';
+        if (! $keyInfo) {
+            $pfx = $this->sigNode->lookupPrefix(self::XMLDSIGNS);
+            if (! empty($pfx)) {
+                $dsig_pfx = $pfx.":";
+            }
+            $inserted = false;
+            $keyInfo = $baseDoc->createElementNS(self::XMLDSIGNS, $dsig_pfx.'KeyInfo');
+
+            $query = "./secdsig:Object";
+            $nodeset = $xpath->query($query, $this->sigNode);
+            if ($sObject = $nodeset->item(0)) {
+                $sObject->parentNode->insertBefore($keyInfo, $sObject);
+                $inserted = true;
+            }
+
+            if (! $inserted) {
+                $this->sigNode->appendChild($keyInfo);
+            }
+        } else {
+            $pfx = $keyInfo->lookupPrefix(self::XMLDSIGNS);
+            if (! empty($pfx)) {
+                $dsig_pfx = $pfx.":";
+            }
+        }
+
+
+
+        // Add all certs if there are more than one
+        $certs = self::staticGet509XCerts($cert, $isPEMFormat);
+
+        // Attach all certificate nodes as binary security tokens
+        $ws_pfx = "";
+        $pfx = $keyInfo->lookupPrefix(self::WSSENS);
+        if (! empty($pfx)) {
+            $ws_pfx = $pfx.":";
+        }
+        foreach ($certs as $X509Cert) {
+            $x509CertNode = $baseDoc->createElementNS(self::WSSENS, $ws_pfx.'BinarySecurityToken', $X509Cert);
+            $x509CertNode->SetAttribute("EncodingType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary");
+            $x509CertNode->SetAttribute("ValueType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3");
+
+            $id = "key-" . sha1(base64_decode($X509Cert));
+            if (! empty($key_id_prefix_ns)) {
+                $x509CertNode->SetAttributeNS($key_id_prefix_ns, $key_id_prefix.":".$key_id_name, $id);
+            } else {
+                $x509CertNode->SetAttribute($key_id_name, $id);
+            }
+
+            $this->securityTokenNodes[] = $x509CertNode;
+
+            $stref = $baseDoc->createElementNS(self::WSSENS, $ws_pfx.'SecurityTokenReference');
+            $ref = $baseDoc->createElementNS(self::WSSENS, $ws_pfx.'Reference');
+            $ref->SetAttribute("URI", "#".$id);
+            $ref->SetAttribute("ValueType", "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3");
+            $stref->appendChild($ref);
+            $keyInfo->appendChild($stref);
         }
     }
 


### PR DESCRIPTION
Clone of PULLREQ. github.com/robrichards/xmlseclibs/pull/96/files
## \- for my fork of robrichards/xmlseclibs.

Some SOAP service vendors will add the signing certificate outside the ds:Signature node for some reason, e.g.:

```
<soapenv:Envelope>
    <soapenv:Header>
        <wsse:Security>
            <wsse:BinarySecurityToken wsu:Id="X509-3F7C9B4526B25D842E1376550971248253">MIICmjCCAg...</wsse:BinarySecurityToken>
            <ds:Signature>
                <ds:SignedInfo>...</ds:SignedInfo>
                <ds:SignatureValue>...</ds:SignatureValue>
                <ds:KeyInfo>
                    <wsse:SecurityTokenReference>
                        <wsse:Reference URI="#X509-3F7C9B4526B25D842E1376550971248253" />
                    </wsse:SecurityTokenReference>
                </ds:KeyInfo>
            </ds:Signature>
        </wsse:Security>
    </soapenv:Header>
    <soapenv:Body>...</soapenv:Body>
</soapenv:Envelope>
```

These commits add support for this format.
To add a public key to a signed document in this manner, use:

```
// ...
// Create a new (private) Security key
$objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type'=>'private'));

// Load the private key
list( $cert_file, $passphrase ) = Config::get( "signing_certificate" );
$objKey->loadKey( $cert_file, TRUE );
if ( !empty($passphrase) )
    $objKey->passphrase = $passphrase;

// Sign the XML file
$objDSig->sign($objKey);

// Add the associated public key to the signature
$objDSig->add509CertByReference( file_get_contents($cert_file) );

// Append the signature to the XML
$objDSig->appendSignature( $dotted_line, true );
```
